### PR TITLE
Fix binary attachment and Content-Disposition header handling

### DIFF
--- a/src/MessagePart.php
+++ b/src/MessagePart.php
@@ -129,16 +129,16 @@ class MessagePart implements \JsonSerializable
 
     public function isAttachment(): bool
     {
-        return str_starts_with($this->getHeader('Content-Disposition', ''), 'attachment');
+        return str_starts_with(strtolower($this->getHeader('Content-Disposition', '')), 'attachment');
     }
 
     public function getFilename(): string
     {
-        if (preg_match('/filename=([^;]+)/', $this->getHeader('Content-Disposition'), $matches)) {
+        if (preg_match('/filename=([^;]+)/i', $this->getHeader('Content-Disposition'), $matches)) {
             return trim($matches[1], '"');
         }
 
-        if (preg_match('/name=([^;]+)/', $this->getContentType(), $matches)) {
+        if (preg_match('/name=([^;]+)/i', $this->getContentType(), $matches)) {
             return trim($matches[1], '"');
         }
 

--- a/src/MessagePart.php
+++ b/src/MessagePart.php
@@ -99,11 +99,17 @@ class MessagePart implements \JsonSerializable
 
     public function getContent(): string
     {
+        $content = $this->content;
+
         if (strtolower($this->getHeader('Content-Transfer-Encoding', '')) === 'base64') {
-            return Utils::normaliseLineEndings(base64_decode($this->content));
+            $content = base64_decode($content);
         }
 
-        return Utils::normaliseLineEndings($this->content);
+        if ($this->isAttachment()) {
+            return $content;
+        }
+
+        return Utils::normaliseLineEndings($content);
     }
 
     public function isHtml(): bool

--- a/tests/Unit/MessageTest.php
+++ b/tests/Unit/MessageTest.php
@@ -425,3 +425,41 @@ EOF;
         ->and($message->getParts()[1]->isAttachment())->toBe(true)
         ->and($message->getParts()[1]->getContent())->toBeEmpty();
 });
+
+it('can parse mixed-case attachment headers', function () {
+    $messageString = <<<EOF
+CoNtEnT-tYpE: mUlTiPaRt/MiXeD; bOuNdArY=ABCdef; fIlEnAmE=ABCdef
+
+--ABCdef
+CoNtEnT-dIsPoSiTiOn: AtTaChMeNt
+
+TeSt
+EOF;
+
+    $message = Message::fromString($messageString);
+
+    expect($message->getParts())->toHaveCount(1)
+        ->and($message->getParts()[0]->isAttachment())->toBe(true)
+        ->and($message->getAttachments())->toHaveCount(1)
+        ->and($message->getAttachments()[0]->getFilename())->toBe('ABCdef')
+        ->and($message->getAttachments()[0]->getContent())->toBe('TeSt');
+});
+
+it('preserves binary attachment content', function () {
+    $messageString = <<<EOF
+CONTENT-TYPE: MULTIPART/MIXED; BOUNDARY=ABCdef; NAME=ABCdef
+
+--ABCdef
+CONTENT-DISPOSITION: ATTACHMENT
+CONTENT-TRANSFER-ENCODING: BASE64
+
+AAECDQoNDQoK/f7/
+EOF;
+
+    $message = Message::fromString($messageString);
+
+    expect($message->getAttachments())->toHaveCount(1)
+        ->and($message->getAttachments()[0]->getFilename())->toBe('ABCdef')
+        ->and($message->getAttachments()[0]->getContent())
+            ->toBe("\x0\x1\x2\r\n\r\r\n\n\xFD\xFE\xFF");
+});


### PR DESCRIPTION
While trying to use this library I have noticed two problems:

1. Some binary attachments in S/MIME signed e-mail were rejected by the ASN.1 parser. It turns out that the `0x0D 0x0A` byte sequence is unconditionally replaced by `0x0A`. Solution: do not touch attachments, return their content as-is.

2. `Content-Disposition` header is case-sensitive, even though relevant documentation states it must be case-insensitive. Solution: case fold value before comparison and add `i` flag to regexps.